### PR TITLE
remove BUILDPACK_URL

### DIFF
--- a/app.json
+++ b/app.json
@@ -8,8 +8,5 @@
         "golang",
         "testing",
         "rest"
-    ],
-    "env": {
-        "BUILDPACK_URL": "https://github.com/heroku/heroku-buildpack-go.git"
-    }
+    ]
 }


### PR DESCRIPTION
This isn't needed since we launched Go support.