### PR TITLE
use ioutil.ReadDir to get sorted file list

### DIFF
--- a/shaas.go
+++ b/shaas.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"html"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -85,7 +86,7 @@ func handleAny(res http.ResponseWriter, req *http.Request) {
 
 func handleGet(res http.ResponseWriter, req *http.Request, path *os.File, pathInfo os.FileInfo) {
 	if pathInfo.Mode().IsDir() {
-		fileInfos, err := path.Readdir(0)
+		fileInfos, err := ioutil.ReadDir(path.Name())
 		if err != nil {
 			handleError(res, req, err, http.StatusInternalServerError, "Error reading directory")
 			return


### PR DESCRIPTION
[ioutil.ReadDir](https://golang.org/pkg/io/ioutil/#ReadDir) returns a slice of `os.FileInfo`, sorted by name. This makes the HTML file list a bit nicer.