### PR TITLE
Export slug idempotently

### DIFF
--- a/.profile
+++ b/.profile
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# runs on start up on heroku
+
+set -e
+
+# exports the slug for download at http://shaas.example.com/app/slug.tgz
+
+slug_file=/app/slug.tgz
+if [ ! -f $slug_file ]; then
+    slug_tmp_file=/tmp/slug.tgz
+    tar cz --transform s,^./,./app/, --owner=root -C /app . > $slug_tmp_file
+    mv $slug_tmp_file $slug_file
+fi

--- a/.profile.d/slug-export.sh
+++ b/.profile.d/slug-export.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-# runs on start up on heroku
-# exports the slug for download at http://shaas.example.com/app/slug.tgz
-
-tar cz --transform s,^./,./app/, --owner=root -C /app . > /tmp/slug.tgz
-mv /tmp/slug.tgz /app/slug.tgz


### PR DESCRIPTION
Only write the slug file once on start up in script is run more than once. This also moves the script from [.profile.d (for buildpacks) to .profile (for app)](https://devcenter.heroku.com/articles/buildpack-api#profile-d-scripts).

cc: @amerine 