### PR TITLE
Set GZIP=-n

### DIFF
--- a/.profile
+++ b/.profile
@@ -9,7 +9,7 @@ set -e
 slug_file=/app/slug.tgz
 if [ ! -f $slug_file ]; then
     slug_tmp_file=/tmp/slug.tgz
-    tar cz --transform s,^./,./app/, --owner=root -C /app . > $slug_tmp_file
+    GZIP=-n tar cz --transform s,^./,./app/, --owner=root -C /app . > $slug_tmp_file
     mv $slug_tmp_file $slug_file
 
     echo SHA256:$(shasum --algorithm 256 $slug_file | cut -f 1 -d ' ') | tr -d '\n' > ${slug_file}.sha256


### PR DESCRIPTION
This sets `GZIP=-n` on `tar` to ensure that the slug file (and therefore the SHA256 checksum) is the same among all the shaas web dynos. Without this, we cannot have shaas scaled > 1; otherwise, the checksum will be different for each dyno because the timestamps are slightly different.