### PR TITLE
Sort slug files and set group

### DIFF
--- a/.profile
+++ b/.profile
@@ -9,7 +9,9 @@ set -e
 slug_file=/app/slug.tgz
 if [ ! -f $slug_file ]; then
     slug_tmp_file=/tmp/slug.tgz
-    GZIP=-n tar cz --transform s,^./,./app/, --owner=root -C /app . > $slug_tmp_file
+    find /app -type f -print0 | \
+        sort -z | \
+        GZIP=-n tar cz -T - --null --transform s,^app/,./app/, --owner=root --group=root > $slug_tmp_file
     mv $slug_tmp_file $slug_file
 
     echo SHA256:$(shasum --algorithm 256 $slug_file | cut -f 1 -d ' ') | tr -d '\n' > ${slug_file}.sha256


### PR DESCRIPTION
Turns out that `GZIP=-n` (see https://github.com/heroku/shaas/pull/9) was not enough to make the checksum consistent between dynos. That made the checksum consistent on a single dyno, but not between web.1 and web.2 because the file order and groups could be different on every dyno. This fixes that by:
 - First sorting the file names and piping them into `tar`
 - Setting the `--group` option

I branch deployed this to `dogwood-shaas` and ran ftests and direwolf on it with it scaled to 2 and seems to be working fine this time around. 