### PR TITLE
Make /app dir

### DIFF
--- a/.profile
+++ b/.profile
@@ -9,6 +9,7 @@ set -e
 slug_file=/app/slug.tgz
 if [ ! -f $slug_file ]; then
     slug_tmp_file=/tmp/slug.tgz
+    mkdir -p /app
     cd /app
     find . -type f -print0 | \
         sort -z | \


### PR DESCRIPTION
I was experimenting with the new Heroku container registry, but the `/app` dir doesn't exist by default there like it did with a slug, so it was failing to start the dyno. This fixes it.