### PR TITLE
set +e after exporting slug file

### DIFF
--- a/.profile
+++ b/.profile
@@ -18,3 +18,5 @@ if [ ! -f $slug_file ]; then
 
     echo SHA256:$(shasum --algorithm 256 $slug_file | cut -f 1 -d ' ') | tr -d '\n' > ${slug_file}.sha256
 fi
+
+set +e


### PR DESCRIPTION
Leaving -e set would prevent the exit code for scripts running in scope of this .profile from propagating properly. Notably, if you ran `shaas` as a Heroku application and then ran something like `heroku run --exit-code -- curl --fail http://example.com/` – the exit code would not be properly propagated because the script would just exit with a generic exit code of `1` rather than the code that was raised by the actual failure in the script. This _should_ fix that by setting `+e` at the end of the slug export in the .profile.