### PR TITLE
Get shaas to build with `docker`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,16 @@
-FROM golang:1.4.2-onbuild
+FROM golang as builder
+
+WORKDIR $GOPATH/src/github.com/heroku/shaas
+ADD . $GOPATH/src/github.com/heroku/shaas
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=amd64
+RUN go install
+
+FROM ubuntu
+
+RUN apt-get update && apt-get install -y bash && apt-get install -y curl
+WORKDIR /root/
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=builder /go/bin/shaas .
 EXPOSE 5000
+
+ENTRYPOINT ["/root/shaas"]


### PR DESCRIPTION
Update `Dockerfile` so that `shaas` can build with the latest Go image and run on the latest ubuntu