### PR TITLE
go/vendor: Force golang 1.13 and use goInstall

### DIFF
--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -29,5 +29,9 @@
 			"revisionTime": "2017-01-10T03:16:11Z"
 		}
 	],
-	"rootPath": "github.com/heroku/shaas"
+	"rootPath": "github.com/heroku/shaas",
+	"heroku": {
+		"install": ["./..."],
+		"goVersion": "go1.13"
+	}
 }


### PR DESCRIPTION
This bumps the golang version for the platform build to 1.13, also specifies install to address tehse two warnings:

```shell
remote:  !!    The 'heroku.goVersion' field is not specified in 'vendor/vendor.json'.
remote:  !!
remote:  !!    Defaulting to go1.12.12
remote:  !!
remote:  !!    For more details see: https://devcenter.heroku.com/articles/go-apps-with-govendor#build-configuration
remote:  !!
remote: -----> New Go Version, clearing old cache
remote: -----> Installing go1.12.12
remote: -----> Fetching go1.12.12.linux-amd64.tar.gz... done
remote: -----> Fetching govendor... done
```

and

```shell
remote:  !!    Installing package '.' (default)
remote:  !!
remote:  !!    To install a different package spec set 'heroku.install' in 'vendor/vendor.json'
remote:  !!
remote:  !!    For more details see: https://devcenter.heroku.com/articles/go-apps-with-govendor#build-configuration
remote:  !!
``` 

