### PR TITLE
Read-only Access & FTest Enhancements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ WORKDIR /app
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /go/bin/shaas .
+COPY --from=builder /go/src/github.com/heroku/shaas/bin/pseudo-interactive-bash /app/bin/pseudo-interactive-bash
 
 EXPOSE 5000
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API to inspect and execute scripts in a server's environment via HTTP and WebSoc
 
 ## Running
 
-Because this application gives clients full access to the server, it is highly recommended to run it inside of some kind of containerized environment, such as [Heroku](http://www.heroku.com) or [Docker](https://www.docker.com/). Even in a containerized environment, you may wish to set a username and password, for use via HTTP basic authentication, by setting `BASIC_AUTH=user:password` in the environment before starting. To only allow `GET` requests and disallow websockets, set `READONLY` in the environment.
+Because this application gives clients full access to the server, it is highly recommended to run it inside of some kind of containerized environment, such as [Heroku](http://www.heroku.com) or [Docker](https://www.docker.com/). Even in a containerized environment, you may wish to set a username and password, for use via HTTP basic authentication, by setting `BASIC_AUTH=user:password` in the environment before starting. To only allow `GET` requests and disallow websockets, set `READ_ONLY` in the environment.
 
 ### Heroku
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API to inspect and execute scripts in a server's environment via HTTP and WebSoc
 
 ## Running
 
-Because this application gives clients full access to the server, it is highly recommended to run it inside of some kind of containerized environment, such as [Heroku](http://www.heroku.com) or [Docker](https://www.docker.com/). Even in a containerized environment, you may wish to set a username and password, for use via HTTP basic authentication, by setting `BASIC_AUTH=user:password` in the environment before starting. To only allow `GET` requests, set `READONLY` in the environment.
+Because this application gives clients full access to the server, it is highly recommended to run it inside of some kind of containerized environment, such as [Heroku](http://www.heroku.com) or [Docker](https://www.docker.com/). Even in a containerized environment, you may wish to set a username and password, for use via HTTP basic authentication, by setting `BASIC_AUTH=user:password` in the environment before starting. To only allow `GET` requests and disallow websockets, set `READONLY` in the environment.
 
 ### Heroku
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ API to inspect and execute scripts in a server's environment via HTTP and WebSoc
 
 ## Running
 
-Because this application gives clients full access to the server, it is highly recommended to run it inside of some kind of containerized environment, such as [Heroku](http://www.heroku.com) or [Docker](https://www.docker.com/). Even in a containerized environment, you may wish to set a username and password, for use via HTTP basic authentication, by setting `BASIC_AUTH=user:password` in the environment before starting. 
+Because this application gives clients full access to the server, it is highly recommended to run it inside of some kind of containerized environment, such as [Heroku](http://www.heroku.com) or [Docker](https://www.docker.com/). Even in a containerized environment, you may wish to set a username and password, for use via HTTP basic authentication, by setting `BASIC_AUTH=user:password` in the environment before starting. To only allow `GET` requests, set `READONLY` in the environment.
 
 ### Heroku
 

--- a/ftest/docker-compose.yml
+++ b/ftest/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.8"
+services:
+  shaas.default:
+    build:
+      context: ..
+    ports:
+      - "5000:5000"
+  shaas.auth:
+    build:
+      context: ..
+    ports:
+      - "5001:5000"
+    environment:
+      - BASIC_AUTH=user:pass
+  shaas.readonly:
+    build:
+      context: ..
+    ports:
+      - "5002:5000"
+    environment:
+      - READ_ONLY=1

--- a/ftest/http_test.go
+++ b/ftest/http_test.go
@@ -70,3 +70,15 @@ func TestPostDir(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, strings.TrimPrefix(env.fixturesUrl(env.services[ServiceDefault]), env.baseUrl(env.services[ServiceDefault]))+"\n", string(body))
 }
+
+func TestReadonlyAllowsGet(t *testing.T) {
+	res, err := http.Get(env.fixturesUrl(env.services[ServiceReadonly]) + "/a")
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func TestReadonlyForbidsPost(t *testing.T) {
+	res, err := http.Post(env.fixturesUrl(env.services[ServiceReadonly])+"/a", "", nil)
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusMethodNotAllowed, res.StatusCode)
+}

--- a/ftest/http_test.go
+++ b/ftest/http_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGetFile(t *testing.T) {
-	res, err := http.Get(env.fixturesUrl() + "/a")
+	res, err := http.Get(env.fixturesUrl(env.services[ServiceDefault]) + "/a")
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 
@@ -23,13 +23,13 @@ func TestGetFile(t *testing.T) {
 }
 
 func TestGetFile_NotFound(t *testing.T) {
-	res, err := http.Get(env.fixturesUrl() + "/b")
+	res, err := http.Get(env.fixturesUrl(env.services[ServiceDefault]) + "/b")
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusNotFound, res.StatusCode)
 }
 
 func TestGetDir(t *testing.T) {
-	res, err := http.Get(env.fixturesUrl())
+	res, err := http.Get(env.fixturesUrl(env.services[ServiceDefault]))
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 
@@ -46,7 +46,7 @@ func TestGetDir(t *testing.T) {
 }
 
 func TestPostFile(t *testing.T) {
-	res, err := http.Post(env.baseUrl()+"/usr/bin/factor", "", strings.NewReader("42"))
+	res, err := http.Post(env.baseUrl(env.services[ServiceDefault])+"/usr/bin/factor", "", strings.NewReader("42"))
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 
@@ -56,17 +56,17 @@ func TestPostFile(t *testing.T) {
 }
 
 func TestPostFile_NotFound(t *testing.T) {
-	res, err := http.Post(env.fixturesUrl()+"/b", "", strings.NewReader(""))
+	res, err := http.Post(env.fixturesUrl(env.services[ServiceDefault])+"/b", "", strings.NewReader(""))
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusNotFound, res.StatusCode)
 }
 
 func TestPostDir(t *testing.T) {
-	res, err := http.Post(env.fixturesUrl(), "", strings.NewReader("pwd"))
+	res, err := http.Post(env.fixturesUrl(env.services[ServiceDefault]), "", strings.NewReader("pwd"))
 	assert.Nil(t, err)
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 
 	body, err := ioutil.ReadAll(res.Body)
 	assert.Nil(t, err)
-	assert.Equal(t, strings.TrimPrefix(env.fixturesUrl(), env.baseUrl())+"\n", string(body))
+	assert.Equal(t, strings.TrimPrefix(env.fixturesUrl(env.services[ServiceDefault]), env.baseUrl(env.services[ServiceDefault]))+"\n", string(body))
 }

--- a/ftest/setup_test.go
+++ b/ftest/setup_test.go
@@ -146,6 +146,11 @@ func (env *TestingEnvironment) destroy() error {
 }
 
 func (env *TestingEnvironment) baseUrl(svc TestingEnvironmentService) string {
+	auth := ""
+	if svc.Auth != "" {
+		auth = fmt.Sprintf("%s@", svc.Auth)
+	}
+
 	host := "localhost"
 	if b2dUrlStr, ok := os.LookupEnv("DOCKER_HOST"); ok {
 		b2dUrl, err := url.Parse(b2dUrlStr)
@@ -155,7 +160,7 @@ func (env *TestingEnvironment) baseUrl(svc TestingEnvironmentService) string {
 		host = strings.SplitAfter(b2dUrl.Host, ":")[0]
 	}
 
-	return fmt.Sprintf("http://%s:%d", host, svc.Port)
+	return fmt.Sprintf("http://%s%s:%d", auth, host, svc.Port)
 }
 
 func (env *TestingEnvironment) fixturesUrl(svc TestingEnvironmentService) string {


### PR DESCRIPTION
To protect the shaas server from file manipulation, this adds a support for read-only access. If `READ_ONLY` is set in the environment, only `GET` requests are supported and WebSockets is disabled. Note, this feature is orthogonal to the existing basic auth feature.

The actual change (https://github.com/heroku/shaas/commit/a383aace2de774b632fef76086f42889849ccaff) is quite small, but this uncovered some problems with WebSockets and deficiencies in Ftests, so there are fixes for those too.

I noticed that we don't have CI on this repo, so made a small attempt to [add CirlceCI](https://github.com/heroku/shaas/compare/circleci-project-setup), but the use of Docker to run these Ftests makes this a little more complicated than the scope of this issue. We can tackle that separately.