### PR TITLE
Add test health endpoint

### DIFF
--- a/ftest/http_test.go
+++ b/ftest/http_test.go
@@ -13,6 +13,23 @@ import (
 	"github.com/heroku/shaas/pkg"
 )
 
+func TestHealthEndpoint(t *testing.T) {
+	uri, err := url.Parse(env.baseUrl(env.services[ServiceAuth]) + "/health")
+	assert.Nil(t, err)
+	uri.User = nil
+
+	res, err := http.Get(uri.String())
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+
+	q := uri.Query()
+	q.Add("responseCode", "204")
+	uri.RawQuery = q.Encode()
+	res, err = http.Get(uri.String())
+	assert.Nil(t, err)
+	assert.Equal(t, http.StatusNoContent, res.StatusCode)
+}
+
 func TestGetFile(t *testing.T) {
 	res, err := http.Get(env.fixturesUrl(env.services[ServiceDefault]) + "/a")
 	assert.Nil(t, err)

--- a/ftest/http_test.go
+++ b/ftest/http_test.go
@@ -23,7 +23,7 @@ func TestHealthEndpoint(t *testing.T) {
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 
 	q := uri.Query()
-	q.Add("responseCode", "204")
+	q.Add("status", "204")
 	uri.RawQuery = q.Encode()
 	res, err = http.Get(uri.String())
 	assert.Nil(t, err)

--- a/shaas.go
+++ b/shaas.go
@@ -27,6 +27,11 @@ var (
 	readonly               bool
 )
 
+const (
+	defaultResponseStatusCode = 200
+	defaultResponseDelay      = 0
+)
+
 func main() {
 	if basicAuth := os.Getenv("BASIC_AUTH"); basicAuth != "" {
 		requireBasicAuth = true
@@ -91,24 +96,12 @@ func handleExit(res http.ResponseWriter, req *http.Request) {
 }
 
 func handleHealth(res http.ResponseWriter, req *http.Request) {
-	responseCode := 200
-	var err error
-	if c := req.URL.Query().Get("responseCode"); c != "" {
-		if responseCode, err = strconv.Atoi(c); err != nil {
-			responseCode = 200
-		}
-	}
-
-	delayMilliSecs := 10
-	if delay := req.URL.Query().Get("delay"); delay != "" {
-		if delayMilliSecs, err = strconv.Atoi(delay); err != nil {
-			delayMilliSecs = 10
-		}
-	}
+	status := parseInt(req.URL.Query().Get("status"), defaultResponseStatusCode)
+	delayMilliSecs := parseInt(req.URL.Query().Get("delay"), defaultResponseDelay)
 
 	time.Sleep(time.Duration(delayMilliSecs) * time.Millisecond)
 
-	res.WriteHeader(responseCode)
+	res.WriteHeader(status)
 	res.Write([]byte("OK\n"))
 }
 
@@ -466,4 +459,15 @@ func upperCaseAndUnderscore(r rune) rune {
 	}
 	// TODO: other transformations in spec or practice?
 	return r
+}
+
+func parseInt(s string, d int) int {
+	if s == "" {
+		return d
+	}
+
+	if parsed, err := strconv.Atoi(s); err == nil {
+		return parsed
+	}
+	return d
 }

--- a/shaas.go
+++ b/shaas.go
@@ -46,8 +46,8 @@ func main() {
 		log.Println("at=readonly.disabled")
 	}
 
-	http.HandleFunc("/>/exit", authorize(handleExit))
 	http.HandleFunc("/health", handleHealth)
+	http.HandleFunc("/>/exit", authorize(handleExit))
 	http.HandleFunc("/", authorize(handleAny))
 
 	for _, p := range httpPorts() {
@@ -109,7 +109,7 @@ func handleHealth(res http.ResponseWriter, req *http.Request) {
 	time.Sleep(time.Duration(delayMilliSecs) * time.Millisecond)
 
 	res.WriteHeader(responseCode)
-	res.Write([]byte("OK"))
+	res.Write([]byte("OK\n"))
 }
 
 func handleAny(res http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
adding a `/health` endpoint that can have its return value configured via query params

- `delay`: amount of time in milliseconds to delay by
- `responseCode`: http response code to return, default `200`