### PR TITLE
use unique GID and UID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN go install -mod=vendor
 FROM ubuntu
 
 RUN apt-get update && apt-get install -y bash && apt-get install -y curl lsof traceroute iproute2 iputils-ping dnsutils
-RUN groupadd -g 1000 app
-RUN useradd -s /bin/bash -u 1000 -g 1000 -d /app app
+RUN groupadd -g 1001 app
+RUN useradd -s /bin/bash -u 1001 -g 1001 -d /app app
 RUN mkdir -p /app && chown app:app /app
 
 USER app


### PR DESCRIPTION
https://askubuntu.com/questions/1513927/ubuntu-24-04-docker-images-now-includes-user-ubuntu-with-uid-gid-1000

```
#11 [stage-1 3/9] RUN groupadd -g 1000 app
#11 0.170 groupadd: GID '1000' already exists
#11 ERROR: process "/bin/sh -c groupadd -g 1000 app" did not complete successfully: exit code: 4
------
 > [stage-1 3/9] RUN groupadd -g 1000 app:
0.170 groupadd: GID '1000' already exists
------
Dockerfile:13
--------------------
  11 |     
  12 |     RUN apt-get update && apt-get install -y bash && apt-get install -y curl lsof traceroute iproute2 iputils-ping dnsutils
  13 | >>> RUN groupadd -g 1000 app
  14 |     RUN useradd -s /bin/bash -u 1000 -g 1000 -d /app app
  15 |     RUN mkdir -p /app && chown app:app /app
```