### PR TITLE
Switch back to the public GitHub Actions runners

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: [pub-hk-ubuntu-22.04-small]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: build and push image


### PR DESCRIPTION
This repo was using one of the custom GitHub Actions runners when it did not need to (since it has no need of more compute, ARM CPUs or a static IP; public repos don't need a static IP for Git checkouts).

As such, it's been switched back to the standard GitHub Actions runners, as recommended here:
https://salesforce.quip.com/bu6UA0KImOxJ#temp:C:GZR57becb9df8d94f80b132168fd