### PR TITLE
Support `_method_ on any HTTP method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/heroku/shaas
 
-go 1.23.0
+go 1.23
 
 // +heroku goVersion go1.16
 

--- a/shaas.go
+++ b/shaas.go
@@ -107,7 +107,7 @@ func handleHealth(res http.ResponseWriter, req *http.Request) {
 
 func handleAny(res http.ResponseWriter, req *http.Request) {
 	method := strings.ToUpper(req.Method)
-	if _method := req.URL.Query().Get("_method"); method == "POST" && _method != "" {
+	if _method := req.URL.Query().Get("_method"); _method != "" {
 		method = strings.ToUpper(_method)
 	}
 


### PR DESCRIPTION
The `_method` query param allows for the actual HTTP method to be overridden, but this only works on `POST`. This changes it to work for any method. This change is to support log drains that work via `PATCH`, but could be helpful for other situations too.

The `go 1.23` change is to support a Go buildpack requirement.