### PR TITLE
Correct `GUSINFO` team and product tag in `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 #ECCN:Open Source
-#GUSINFO:Heroku Runtime: Control Plane,Heroku Runtime Control Plane: Fir
+#GUSINFO:Heroku Runtime,Heroku Runtime General
 * @heroku/runtime


### PR DESCRIPTION
The `#GUSINFO:` line in `CODEOWNERS` names a product tag (`Heroku Runtime Control Plane: Fir`) that does not exist in GUS. This change sets it to `Heroku Runtime,Heroku Runtime General`.

This correction was suggested by Claude Code, based on the GitHub owner team (`@heroku/runtime`) and its active product tag in GUS. The reviewer should confirm the new product tag is correct and the most appropriate one for this component.

GUS-W-23525396.